### PR TITLE
Improve asset-url generation API

### DIFF
--- a/uploader/src/test/kotlin/com/cloudinary/UploaderTest.kt
+++ b/uploader/src/test/kotlin/com/cloudinary/UploaderTest.kt
@@ -724,7 +724,7 @@ class UploaderTest(networkLayer: NetworkLayer) {
 
         val explicitData = response.resultOrThrow()
 
-        val url = cloudinary.url {
+        val url = cloudinary.image {
             transformation(transformation)
             extension(Extension.PNG)
             version(explicitData.version!!.toString())

--- a/url-gen/src/main/kotlin/com/cloudinary/Asset.kt
+++ b/url-gen/src/main/kotlin/com/cloudinary/Asset.kt
@@ -18,7 +18,7 @@ internal const val DEFAULT_RESOURCE_TYPE = "image"
 internal const val DEFAULT_DELIVERY_TYPE = "upload"
 
 @TransformationDsl
-data class Url constructor(
+class Asset constructor(
     private val config: Configuration,
     private val cloudName: String = config.cloudName,
     private val publicId: String? = null,
@@ -126,11 +126,14 @@ data class Url constructor(
     }
 
     @TransformationDsl
-    class Builder(private val config: Configuration) : ITransformable<Builder> {
+    class AssetBuilder internal constructor(
+        private val config: Configuration,
+        private var resourceType: String = DEFAULT_RESOURCE_TYPE
+    ) :
+        ITransformable<AssetBuilder> {
         private var cloudName: String = config.cloudName
         private var publicId: String? = null
         private var deliveryType: String? = null
-        private var resourceType: String = DEFAULT_RESOURCE_TYPE
         private var extension: Extension? = null
         private var version: String? = null
         private var transformation: Transformation? = null
@@ -153,6 +156,12 @@ data class Url constructor(
         fun extension(extension: Extension) = apply { this.extension = extension }
         fun version(version: String?) = apply { this.version = version }
         fun transformation(transformation: Transformation) = apply { this.transformation = transformation }
+        fun transformation(transformation: (Transformation.Builder.() -> Unit)? = null) = apply {
+            val builder = Transformation.Builder()
+            transformation?.let { builder.it() }
+            this.transformation = builder.build()
+        }
+
         fun signUrl(signUrl: Boolean) = apply { this.signUrl = signUrl }
         fun authToken(authToken: AuthToken) = apply { this.authToken = authToken }
         fun source(source: String?) = apply { this.source = source }
@@ -167,7 +176,7 @@ data class Url constructor(
 
         override fun add(action: Action) = apply { transformation = (transformation ?: Transformation()).add(action) }
 
-        fun build() = Url(
+        fun build() = Asset(
             config,
             cloudName,
             publicId,

--- a/url-gen/src/main/kotlin/com/cloudinary/Cloudinary.kt
+++ b/url-gen/src/main/kotlin/com/cloudinary/Cloudinary.kt
@@ -18,9 +18,27 @@ class Cloudinary(val config: Configuration) {
 
     val userAgent = "CloudinaryKotlin/$SDK_VERSION"
 
-    fun url(url: (Url.Builder.() -> Unit)? = null): Url {
-        val builder = Url.Builder(config)
-        url?.let { builder.it() }
+    fun raw(options: (Asset.AssetBuilder.() -> Unit)? = null): Asset {
+        val builder = Asset.AssetBuilder(config, "raw")
+        options?.let { builder.it() }
+        return builder.build()
+    }
+
+    fun image(options: (Asset.AssetBuilder.() -> Unit)? = null): Asset {
+        val builder = Asset.AssetBuilder(config, "image")
+        options?.let { builder.it() }
+        return builder.build()
+    }
+
+    fun media(options: (Asset.AssetBuilder.() -> Unit)? = null): Asset {
+        val builder = Asset.AssetBuilder(config)
+        options?.let { builder.it() }
+        return builder.build()
+    }
+
+    fun video(options: (Asset.AssetBuilder.() -> Unit)? = null): Asset {
+        val builder = Asset.AssetBuilder(config, "video")
+        options?.let { builder.it() }
         return builder.build()
     }
 

--- a/url-gen/src/test/kotlin/com/cloudinary/AuthTokenTest.kt
+++ b/url-gen/src/test/kotlin/com/cloudinary/AuthTokenTest.kt
@@ -56,9 +56,8 @@ class AuthTokenTest {
             Cloudinary(cloudinary.config.copy(urlConfig = cloudinary.config.urlConfig.copy(privateCdn = true)))
         var message = "should add token if authToken is globally set and signed = true"
         var url =
-            cloudinary.url {
+            cloudinary.image {
                 signUrl(true)
-                resourceType("image")
                 deliveryType("authenticated")
                 version("1486020273")
             }.generate("sample.jpg")
@@ -68,9 +67,8 @@ class AuthTokenTest {
             url
         )
         message = "should add token for 'public' resource"
-        url = cloudinary.url {
+        url = cloudinary.image {
             signUrl(true)
-            resourceType("image")
             deliveryType("public")
             version("1486020273")
         }.generate("sample.jpg")
@@ -81,7 +79,7 @@ class AuthTokenTest {
         )
         message = "should not add token if signed is false"
         url =
-            cloudinary.url {
+            cloudinary.image {
                 resourceType("image")
                 deliveryType("authenticated")
                 version("1486020273")
@@ -94,7 +92,7 @@ class AuthTokenTest {
         )
         message =
             "should not add token if authToken is globally set but null auth token is explicitly set and signed = true"
-        url = cloudinary.url {
+        url = cloudinary.image {
             authToken(NULL_AUTH_TOKEN)
             signUrl(true)
             resourceType("image")
@@ -107,7 +105,7 @@ class AuthTokenTest {
             url
         )
         message = "explicit authToken should override global setting"
-        url = cloudinary.url {
+        url = cloudinary.image {
             signUrl(true)
             authToken(AuthToken(key = ALT_KEY, startTime = 222222222, duration = 100))
             resourceType("image")
@@ -122,7 +120,7 @@ class AuthTokenTest {
             url
         )
         message = "should compute expiration as start time + duration"
-        url = cloudinary.url {
+        url = cloudinary.image {
             signUrl(true)
             authToken(AuthToken(key = KEY, startTime = 11111111, duration = 300))
             deliveryType("authenticated")

--- a/url-gen/src/test/kotlin/com/cloudinary/UrlTest.kt
+++ b/url-gen/src/test/kotlin/com/cloudinary/UrlTest.kt
@@ -32,36 +32,36 @@ class UrlTest {
             urlConfig = urlConfig
         )
 
-        assertEquals("https://secure.api.com/sample", Url(config).generate("sample"))
-        assertEquals("http://my.domain.org/sample", Url(config, secure = false).generate("sample"))
+        assertEquals("https://secure.api.com/sample", Asset(config).generate("sample"))
+        assertEquals("http://my.domain.org/sample", Asset(config, secure = false).generate("sample"))
     }
 
     @Test
     fun testUrlSuffixWithDotOrSlash() {
         val errors = arrayOfNulls<Boolean>(4)
         try {
-            cloudinary.url {
+            cloudinary.image {
                 urlSuffix("dsfdfd.adsfad")
             }.generate("publicId")
         } catch (e: IllegalArgumentException) {
             errors[0] = true
         }
         try {
-            cloudinary.url {
+            cloudinary.image {
                 urlSuffix("dsfdfd/adsfad")
             }.generate("publicId")
         } catch (e: IllegalArgumentException) {
             errors[1] = true
         }
         try {
-            cloudinary.url {
+            cloudinary.image {
                 urlSuffix("dsfd.fd/adsfad")
             }.generate("publicId")
         } catch (e: IllegalArgumentException) {
             errors[2] = true
         }
         try {
-            cloudinary.url {
+            cloudinary.image {
                 urlSuffix("dsfdfdaddsfad")
             }.generate("publicId")
         } catch (e: IllegalArgumentException) {
@@ -75,13 +75,13 @@ class UrlTest {
 
     @Test
     fun testCloudName() { // should use cloud_name from config
-        val result = cloudinary.url().generate("test")
+        val result = cloudinary.image().generate("test")
         assertEquals(DEFAULT_UPLOAD_PATH + "test", result)
     }
 
     @Test
     fun testCloudNameOptions() { // should allow overriding cloud_name in options
-        val result = cloudinary.url {
+        val result = cloudinary.image {
             cloudName("test321")
         }.generate("test")
         assertEquals("http://res.cloudinary.com/test321/image/upload/test", result)
@@ -89,7 +89,7 @@ class UrlTest {
 
     @Test
     fun testSecureDistribution() { // should use default secure distribution if secure=TRUE
-        val result = cloudinary.url {
+        val result = cloudinary.image {
             secure(true)
         }.generate("test")
         assertEquals("https://res.cloudinary.com/test123/image/upload/test", result)
@@ -98,7 +98,7 @@ class UrlTest {
     @Test
     fun testSecureDistributionOverwrite() { // should allow overwriting secure distribution if secure=TRUE
         val result =
-            cloudinary.url {
+            cloudinary.image {
                 secure(true)
                 secureDistribution("something.else.com")
             }.generate("test")
@@ -110,7 +110,7 @@ class UrlTest {
         val newConfig =
             cloudinary.config.copy(urlConfig = cloudinary.config.urlConfig.copy(secureDistribution = "config.secure.distribution.com"))
 
-        val result = Cloudinary(newConfig).url {
+        val result = Cloudinary(newConfig).image {
             secure(true)
         }.generate("test")
         assertEquals("https://config.secure.distribution.com/test123/image/upload/test", result)
@@ -121,7 +121,7 @@ class UrlTest {
 // secure_distribution
         val urlConfig = cloudinary.config.urlConfig.copy(secure = true, privateCdn = true)
         val config = cloudinary.config.copy(urlConfig = urlConfig)
-        val result = Cloudinary(config).url().generate("test")
+        val result = Cloudinary(config).image().generate("test")
         assertEquals("https://test123-res.cloudinary.com/image/upload/test", result)
     }
 
@@ -134,7 +134,7 @@ class UrlTest {
             secureDistribution = "something.cloudfront.net"
         )
         val config = cloudinary.config.copy(urlConfig = urlConfig)
-        val result = Cloudinary(config).url().generate("test")
+        val result = Cloudinary(config).image().generate("test")
         assertEquals("https://something.cloudfront.net/image/upload/test", result)
     }
 
@@ -142,14 +142,14 @@ class UrlTest {
     fun testHttpPrivateCdn() { // should not add cloud_name if private_cdn and not secure
         val urlConfig = cloudinary.config.urlConfig.copy(privateCdn = true)
         val config = cloudinary.config.copy(urlConfig = urlConfig)
-        val result = Cloudinary(config).url().generate("test")
+        val result = Cloudinary(config).image().generate("test")
 
         assertEquals("http://test123-res.cloudinary.com/image/upload/test", result)
     }
 
     @Test
     fun testFormat() { // should use format from options
-        val result = cloudinary.url {
+        val result = cloudinary.image {
             extension(Extension.JPG)
         }.generate("test")
         assertEquals(DEFAULT_UPLOAD_PATH + "test.jpg", result)
@@ -157,7 +157,7 @@ class UrlTest {
 
     @Test
     fun testType() { // should use type from options
-        val result = cloudinary.url {
+        val result = cloudinary.image {
             deliveryType("facebook")
         }.generate("test")
         assertEquals("http://res.cloudinary.com/test123/image/facebook/test", result)
@@ -165,21 +165,19 @@ class UrlTest {
 
     @Test
     fun testResourceType() { // should use resource_type from options
-        val result = cloudinary.url {
-            resourceType("raw")
-        }.generate("test")
+        val result = cloudinary.raw().generate("test")
         assertEquals("http://res.cloudinary.com/test123/raw/upload/test", result)
     }
 
     @Test
     fun testIgnoreHttp() { // should ignore http links only if type is not given or is asset
-        var result = cloudinary.url().generate("http://test")
+        var result = cloudinary.image().generate("http://test")
         assertEquals("http://test", result)
-        result = cloudinary.url {
+        result = cloudinary.image {
             deliveryType("asset")
         }.generate("http://test")
         assertEquals("http://test", result)
-        result = cloudinary.url {
+        result = cloudinary.image {
             deliveryType("fetch")
         }.generate("http://test")
         assertEquals("http://res.cloudinary.com/test123/image/fetch/http://test", result)
@@ -187,7 +185,7 @@ class UrlTest {
 
     @Test
     fun testFetch() { // should escape fetch urls
-        val result = cloudinary.url {
+        val result = cloudinary.image {
             deliveryType("fetch")
         }.generate("http://blah.com/hello?a=b")
         assertEquals(
@@ -198,7 +196,7 @@ class UrlTest {
 
     @Test
     fun testCname() { // should support external cname
-        val result = cloudinary.url {
+        val result = cloudinary.image {
             cname("hello.com")
         }.generate("test")
         assertEquals("http://hello.com/test123/image/upload/test", result)
@@ -206,7 +204,7 @@ class UrlTest {
 
     @Test(expected = IllegalArgumentException::class)
     fun testDisallowUrlSuffixInNonUploadTypes() {
-        cloudinary.url {
+        cloudinary.media {
             urlSuffix("hello")
             privateCdn(true)
             deliveryType("facebook")
@@ -215,7 +213,8 @@ class UrlTest {
 
     @Test(expected = IllegalArgumentException::class)
     fun testDisallowUrlSuffixWithSlash() {
-        cloudinary.url {
+        cloudinary.media {
+            resourceType("image")
             urlSuffix("hello/world")
             privateCdn(true)
         }.generate("test")
@@ -223,7 +222,7 @@ class UrlTest {
 
     @Test(expected = IllegalArgumentException::class)
     fun testDisallowUrlSuffixWithDot() {
-        cloudinary.url {
+        cloudinary.image {
             urlSuffix("hello.world")
             privateCdn(true)
         }.generate("test")
@@ -231,13 +230,13 @@ class UrlTest {
 
     @Test
     fun testSupportUrlSuffixForPrivateCdn() {
-        var actual = cloudinary.url {
+        var actual = cloudinary.image {
             urlSuffix("hello")
             privateCdn(true)
         }.generate("test")
         assertEquals("http://test123-res.cloudinary.com/images/test/hello", actual)
         actual =
-            cloudinary.url {
+            cloudinary.image {
                 urlSuffix("hello")
                 privateCdn(true)
                 rotate(Rotate.angle(0))
@@ -249,7 +248,7 @@ class UrlTest {
     @Test
     fun testPutFormatAfterUrlSuffix() {
         val actual =
-            cloudinary.url {
+            cloudinary.image {
                 urlSuffix("hello")
                 privateCdn(true)
                 extension(Extension.JPG)
@@ -260,7 +259,7 @@ class UrlTest {
     @Test
     fun testNotSignTheUrlSuffix() {
         val pattern = Pattern.compile("s--[0-9A-Za-z_-]{8}--")
-        var url = cloudinary.url {
+        var url = cloudinary.image {
             extension(Extension.JPG)
             signUrl(true)
         }.generate("test")!!
@@ -269,7 +268,7 @@ class UrlTest {
         var expectedSignature = url.substring(matcher.start(), matcher.end())
 
         var actual =
-            cloudinary.url {
+            cloudinary.image {
                 extension(Extension.JPG)
                 privateCdn(true)
                 signUrl(true)
@@ -281,7 +280,7 @@ class UrlTest {
             actual
         )
 
-        url = cloudinary.url {
+        url = cloudinary.image {
             extension(Extension.JPG)
             signUrl(true)
             rotate(Rotate.angle(0))
@@ -289,7 +288,7 @@ class UrlTest {
         matcher = pattern.matcher(url)
         matcher.find()
         expectedSignature = url.substring(matcher.start(), matcher.end())
-        actual = cloudinary.url {
+        actual = cloudinary.image {
             extension(Extension.JPG)
             privateCdn(true)
             signUrl(true)
@@ -305,7 +304,7 @@ class UrlTest {
     @Test
     fun testSupportUrlSuffixForRawUploads() {
         val actual =
-            cloudinary.url {
+            cloudinary.image {
                 urlSuffix("hello")
                 privateCdn(true)
                 resourceType("raw")
@@ -316,10 +315,9 @@ class UrlTest {
     @Test
     fun testSupportUrlSuffixForVideoUploads() {
         val actual =
-            cloudinary.url {
+            cloudinary.video {
                 urlSuffix("hello")
                 privateCdn(true)
-                resourceType("video")
             }.generate("test")
         assertEquals("http://test123-res.cloudinary.com/videos/test/hello", actual)
     }
@@ -327,7 +325,7 @@ class UrlTest {
     @Test
     fun testSupportUrlSuffixForAuthenticatedImages() {
         val actual =
-            cloudinary.url {
+            cloudinary.image {
                 urlSuffix("hello")
                 privateCdn(true)
                 resourceType("image")
@@ -340,7 +338,7 @@ class UrlTest {
     @Test
     fun testSupportUrlSuffixForPrivateImages() {
         val actual =
-            cloudinary.url {
+            cloudinary.image {
                 urlSuffix("hello")
                 privateCdn(true)
                 resourceType("image")
@@ -352,13 +350,13 @@ class UrlTest {
 
     @Test
     fun testSupportUseRootPathForPrivateCdn() {
-        var actual = cloudinary.url {
+        var actual = cloudinary.image {
             privateCdn(true)
             useRootPath(true)
         }.generate("test")
         assertEquals("http://test123-res.cloudinary.com/test", actual)
         actual =
-            cloudinary.url {
+            cloudinary.image {
                 privateCdn(true)
                 rotate(Rotate.angle(0))
                 useRootPath(true)
@@ -368,7 +366,7 @@ class UrlTest {
 
     @Test
     fun testSupportUseRootPathTogetherWithUrlSuffixForPrivateCdn() {
-        val actual = cloudinary.url {
+        val actual = cloudinary.image {
             privateCdn(true)
             urlSuffix("hello")
             useRootPath(true)
@@ -378,7 +376,7 @@ class UrlTest {
 
     @Test(expected = IllegalArgumentException::class)
     fun testDisallowUseRootPathIfNotImageUploadForFacebook() {
-        cloudinary.url {
+        cloudinary.image {
             useRootPath(true)
             privateCdn(true)
             deliveryType("facebook")
@@ -387,7 +385,7 @@ class UrlTest {
 
     @Test(expected = IllegalArgumentException::class)
     fun testDisallowUseRootPathIfNotImageUploadForRaw() {
-        cloudinary.url {
+        cloudinary.image {
             useRootPath(true)
             privateCdn(true)
             resourceType("raw")
@@ -397,7 +395,7 @@ class UrlTest {
     @Test
     fun testHttpEscape() { // should escape http urls
         val result =
-            cloudinary.url {
+            cloudinary.image {
                 deliveryType("youtube")
             }.generate("http://www.youtube.com/watch?v=d9NF2edxy-M")
         assertEquals(
@@ -409,7 +407,7 @@ class UrlTest {
     @Test
     fun testFetchFormat() { // should support format for fetch urls
         val result =
-            cloudinary.url {
+            cloudinary.image {
                 extension(Extension.JPG)
                 deliveryType("fetch")
             }.generate("http://cloudinary.com/images/old_logo.png")
@@ -421,9 +419,9 @@ class UrlTest {
 
     @Test
     fun testFolders() { // should add version if public_id contains /
-        var result = cloudinary.url().generate("folder/test")
+        var result = cloudinary.image().generate("folder/test")
         assertEquals(DEFAULT_UPLOAD_PATH + "v1/folder/test", result)
-        result = cloudinary.url {
+        result = cloudinary.image {
             version("123")
         }.generate("folder/test")
         assertEquals(
@@ -434,12 +432,12 @@ class UrlTest {
 
     @Test
     fun testFoldersWithExcludeVersion() { // should not add version if the user turned off forceVersion
-        var result = cloudinary.url {
+        var result = cloudinary.image {
             forceVersion(false)
         }.generate("folder/test")
         assertEquals(DEFAULT_UPLOAD_PATH + "folder/test", result)
         // should still show explicit version if passed by the user
-        result = cloudinary.url {
+        result = cloudinary.image {
             forceVersion(false)
             version("1234")
         }.generate("folder/test")
@@ -448,15 +446,15 @@ class UrlTest {
             result
         )
         // should add version if no value specified for forceVersion:
-        result = cloudinary.url().generate("folder/test")
+        result = cloudinary.image().generate("folder/test")
         assertEquals(DEFAULT_UPLOAD_PATH + "v1/folder/test", result)
         // should add version if forceVersion is true
-        result = cloudinary.url {
+        result = cloudinary.image {
             forceVersion(true)
         }.generate("folder/test")
         assertEquals(DEFAULT_UPLOAD_PATH + "v1/folder/test", result)
         // should not use v1 if explicit version is passed
-        result = cloudinary.url {
+        result = cloudinary.image {
             forceVersion(true)
             version("1234")
         }.generate("folder/test")
@@ -468,13 +466,13 @@ class UrlTest {
 
     @Test
     fun testFoldersWithVersion() { // should not add version if public_id contains version already
-        val result = cloudinary.url().generate("v1234/test")
+        val result = cloudinary.image().generate("v1234/test")
         assertEquals(DEFAULT_UPLOAD_PATH + "v1234/test", result)
     }
 
     @Test
     fun testShorten() { // should allow to shorted image/upload urls
-        val result = cloudinary.url {
+        val result = cloudinary.image {
             shorten(true)
         }.generate("test")
         assertEquals("http://res.cloudinary.com/test123/iu/test", result)
@@ -484,7 +482,7 @@ class UrlTest {
     fun testEscapePublicId() { // should escape public_ids
         val tests = mapOf("a b" to "a%20b", "a+b" to "a%2Bb", "a%20b" to "a%20b", "a-b" to "a-b", "a??b" to "a%3F%3Fb")
         for ((key, value) in tests) {
-            val result = cloudinary.url().generate(key)
+            val result = cloudinary.image().generate(key)
             assertEquals(
                 DEFAULT_UPLOAD_PATH + "" + value,
                 result
@@ -497,20 +495,20 @@ class UrlTest {
         var expected: String =
             DEFAULT_UPLOAD_PATH + "s--Ai4Znfl3--/c_crop,h_20,w_10/v1234/image.jpg"
         var actual =
-            cloudinary.url {
+            cloudinary.image {
                 version("1234")
                 resize(Resize.crop { width(10); height(20) })
                 signUrl(true)
             }.generate("image.jpg")
         assertEquals(expected, actual)
         expected = DEFAULT_UPLOAD_PATH + "s----SjmNDA--/v1234/image.jpg"
-        actual = cloudinary.url {
+        actual = cloudinary.image {
             version("1234")
             signUrl(true)
         }.generate("image.jpg")
         assertEquals(expected, actual)
         expected = DEFAULT_UPLOAD_PATH + "s--Ai4Znfl3--/c_crop,h_20,w_10/image.jpg"
-        actual = cloudinary.url {
+        actual = cloudinary.image {
             resize(Resize.crop { width(10); height(20) })
             signUrl(true)
         }.generate("image.jpg")


### PR DESCRIPTION
* Add `raw()`, `media()`, `image()` and `video()` methods to `Cloudinary`
* Rename `Url` class to `Asset`
* Refactor `AssetBuilder` so it explicitly requires `resource_type`.