### PR TITLE
Remove jcenter dependency

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,11 +1,11 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
-        classpath("com.android.tools.build:gradle:3.1.4")
+        classpath("com.android.tools.build:gradle:4.1.2")
         classpath(kotlin("gradle-plugin", version = "1.3.72"))
     }
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
 
 repositories {
     gradlePluginPortal()
+    mavenCentral()
 }
 
 dependencies {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -4,7 +4,6 @@ plugins {
 
 repositories {
     gradlePluginPortal()
-    jcenter()
 }
 
 dependencies {

--- a/buildSrc/src/main/kotlin/cloudinary_lib.gradle.kts
+++ b/buildSrc/src/main/kotlin/cloudinary_lib.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 
 repositories {
     google()
-    jcenter()
+    mavenCentral()
 }
 
 tasks.withType<GenerateModuleMetadata>().configureEach {

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -12,9 +12,8 @@ dependencies {
     orchidRuntime("io.github.javaeden.orchid:OrchidEditorial:0.21.0")
 }
 
-// 3. Get dependencies from JCenter and Kotlinx Bintray repo
+// 3. Get dependencies from Kotlinx Bintray repo
 repositories {
-    jcenter()
     maven { url = "https://kotlin.bintray.com/kotlinx/" }
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,7 +1,6 @@
 pluginManagement {
     repositories {
         gradlePluginPortal()
-        jcenter()
     }
 }
 rootProject.name = 'cloudinary_kotlin'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,7 @@
 pluginManagement {
     repositories {
         gradlePluginPortal()
+        mavenCentral()
     }
 }
 rootProject.name = 'cloudinary_kotlin'


### PR DESCRIPTION
### Root cause
`jcenter` will stop being supported by the end of march, because of that we want to remove any dependency in `jcenter` currently exists in the SDK
please see the following [link]( https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/)

### Implementation 
Replaced `jcenter` with `mavenCenteral`