### PR TITLE
Update tmpl package to 1.0.5

### DIFF
--- a/devTools/package-lock.json
+++ b/devTools/package-lock.json
@@ -3491,8 +3491,8 @@
       "integrity": "sha512-8hmiGIJMDlwjg7dlJ4yKGLK8EsYqKgPWbG3b4wjJddKNwc7N7Dpn08Df4szr/sZdMVeOstrdYSsqzX6BYbcB+w=="
     },
     "tmpl": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
       "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE="
     },
     "to-fast-properties": {


### PR DESCRIPTION
### Root Cause
Git is complaining about security issues with version `1.0.4` of the `tmpl` package.

### Solution
Update `tmpl` to version `1.0.5` as recommended by Git