### PR TITLE
Fix `e_preview` normalization

### DIFF
--- a/url-gen/src/main/kotlin/com/cloudinary/transformation/expression/Expression.kt
+++ b/url-gen/src/main/kotlin/com/cloudinary/transformation/expression/Expression.kt
@@ -200,7 +200,7 @@ private fun getPattern(): Pattern {
         sb.append(Pattern.quote(op)).append("|")
     }
     sb.deleteCharAt(sb.length - 1)
-    sb.append(")(?=[ _])|").append(PREDEFINED_VARS.keys.joinToString("|", transform = { "(?<!\\$)$it" })).append(")")
+    sb.append(")(?=[ _])|").append(PREDEFINED_VARS.keys.map {":${it}|${it}"}.joinToString("|", transform = { "(?<!\\$)$it" })).append(")")
     pattern = sb.toString()
     return Pattern.compile(pattern)
 }

--- a/url-gen/src/main/kotlin/com/cloudinary/transformation/expression/Expression.kt
+++ b/url-gen/src/main/kotlin/com/cloudinary/transformation/expression/Expression.kt
@@ -200,6 +200,8 @@ private fun getPattern(): Pattern {
         sb.append(Pattern.quote(op)).append("|")
     }
     sb.deleteCharAt(sb.length - 1)
+    // The :${it} part is to prevent normalization of vars with a preceding colon (such as :duration),
+    // It won't be found in PREDEFINED_VARS and so won't be normalized.
     sb.append(")(?=[ _])|").append(PREDEFINED_VARS.keys.map {":${it}|${it}"}.joinToString("|", transform = { "(?<!\\$)$it" })).append(")")
     pattern = sb.toString()
     return Pattern.compile(pattern)

--- a/url-gen/src/test/kotlin/com/cloudinary/transformation/VideoEditTest.kt
+++ b/url-gen/src/test/kotlin/com/cloudinary/transformation/VideoEditTest.kt
@@ -47,13 +47,7 @@ class VideoEditTest {
     }
 
     @Test
-    fun testPreivewAsExpression() {
-        var string1 = VideoEdit.preview {
-            duration(2f)
-        }.toString()
-        var string2 = Expression.expression(VideoEdit.preview {
-            duration(2f)
-        }.toString())
+    fun testPreviewAsExpression() {
         cldAssert("e_preview:duration_2.0", Expression.expression(VideoEdit.preview {
             duration(2f)
         }.toString()))

--- a/url-gen/src/test/kotlin/com/cloudinary/transformation/VideoEditTest.kt
+++ b/url-gen/src/test/kotlin/com/cloudinary/transformation/VideoEditTest.kt
@@ -2,6 +2,7 @@ package com.cloudinary.transformation
 
 import com.cloudinary.cldAssert
 import com.cloudinary.transformation.effect.Effect
+import com.cloudinary.transformation.expression.Expression
 import com.cloudinary.transformation.videoedit.Concatenate
 import com.cloudinary.transformation.videoedit.Transition
 import com.cloudinary.transformation.videoedit.VideoEdit
@@ -43,6 +44,19 @@ class VideoEditTest {
             maximumSegments(3)
             minimumSegmentDuration(3)
         })
+    }
+
+    @Test
+    fun testPreivewAsExpression() {
+        var string1 = VideoEdit.preview {
+            duration(2f)
+        }.toString()
+        var string2 = Expression.expression(VideoEdit.preview {
+            duration(2f)
+        }.toString())
+        cldAssert("e_preview:duration_2.0", Expression.expression(VideoEdit.preview {
+            duration(2f)
+        }.toString()))
     }
 
     @Test


### PR DESCRIPTION
### Brief Summary of Changes

### Root Cause
Normalize function for expression changed variables such as: `duration`

### Implementation
The :${it} part is to prevent normalization of vars with a preceding colon (such as :duration)

#### What does this PR address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [ ] New feature
- [x] Bug fix
- [ ] Adds more tests

#### Are tests included?
- [x] Yes
- [ ] No

#### Reviewer, please note:


#### Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all the tests pass.
