### PR TITLE
Disable analytics if query params or token exist in url

### DIFF
--- a/url-gen/src/main/kotlin/com/cloudinary/asset/Asset.kt
+++ b/url-gen/src/main/kotlin/com/cloudinary/asset/Asset.kt
@@ -162,12 +162,13 @@ abstract class BaseAsset constructor(
                 mutableSource
             ).joinToString("/").cldMergeSlashedInUrl()
 
+
+        //REFACTOR this piece of code.split to 2 ifs if auth token return atuh token, if anaytivcs return with analytics else return url
         var analytics: String? = null
-        var urlObject = URL(url)
-        if (urlConfig.analytics && cloudConfig.authToken == null && urlObject.query == null) {
+        var urlObject = URL(url) // Need to catch the exception here!
+        if (urlConfig.analytics && cloudConfig.authToken == null &&  urlObject.query == null) {
             analytics = "_a=${generateAnalyticsSignature()}"
         }
-
 
         return if (urlConfig.signUrl && cloudConfig.authToken != null && cloudConfig.authToken != NULL_AUTH_TOKEN) {
             val token = cloudConfig.authToken.generate(URL(url).path)

--- a/url-gen/src/main/kotlin/com/cloudinary/asset/Asset.kt
+++ b/url-gen/src/main/kotlin/com/cloudinary/asset/Asset.kt
@@ -162,10 +162,11 @@ abstract class BaseAsset constructor(
                 mutableSource
             ).joinToString("/").cldMergeSlashedInUrl()
 
+        var analytics: String? = null
         var urlObject = URL(url)
-        val analytics = if (urlConfig.analytics && cloudConfig.authToken == null && urlObject.query == null)
-            "_a=${generateAnalyticsSignature()}"
-        else null
+        if (urlConfig.analytics && cloudConfig.authToken == null && urlObject.query == null) {
+            analytics = "_a=${generateAnalyticsSignature()}"
+        }
 
 
         return if (urlConfig.signUrl && cloudConfig.authToken != null && cloudConfig.authToken != NULL_AUTH_TOKEN) {

--- a/url-gen/src/main/kotlin/com/cloudinary/asset/Asset.kt
+++ b/url-gen/src/main/kotlin/com/cloudinary/asset/Asset.kt
@@ -8,6 +8,7 @@ import com.cloudinary.generateAnalyticsSignature
 import com.cloudinary.transformation.*
 import com.cloudinary.util.*
 import java.io.UnsupportedEncodingException
+import java.net.MalformedURLException
 import java.net.URL
 import java.net.URLDecoder
 import java.nio.charset.Charset
@@ -162,20 +163,21 @@ abstract class BaseAsset constructor(
                 mutableSource
             ).joinToString("/").cldMergeSlashedInUrl()
 
-
-        //REFACTOR this piece of code.split to 2 ifs if auth token return atuh token, if anaytivcs return with analytics else return url
-        var analytics: String? = null
-        var urlObject = URL(url) // Need to catch the exception here!
-        if (urlConfig.analytics && cloudConfig.authToken == null &&  urlObject.query == null) {
-            analytics = "_a=${generateAnalyticsSignature()}"
-        }
-
-        return if (urlConfig.signUrl && cloudConfig.authToken != null && cloudConfig.authToken != NULL_AUTH_TOKEN) {
+        if (urlConfig.signUrl && cloudConfig.authToken != null && cloudConfig.authToken != NULL_AUTH_TOKEN) {
             val token = cloudConfig.authToken.generate(URL(url).path)
-            "$url?$token".joinWithValues(analytics, separator = "&")
-        } else {
-            url.joinWithValues(analytics, separator = "?")
+            return "$url?$token"
         }
+        try {
+            var urlObject = URL(url)
+            if (urlConfig.analytics && cloudConfig.authToken == null &&  urlObject.query == null) {
+                val analytics = "_a=${generateAnalyticsSignature()}"
+                return url.joinWithValues(analytics, separator = "?")
+            }
+        } catch (exception: MalformedURLException) {
+            return url
+        }
+
+        return url
     }
 
     abstract fun getTransformationString(): String?

--- a/url-gen/src/main/kotlin/com/cloudinary/asset/Asset.kt
+++ b/url-gen/src/main/kotlin/com/cloudinary/asset/Asset.kt
@@ -162,7 +162,11 @@ abstract class BaseAsset constructor(
                 mutableSource
             ).joinToString("/").cldMergeSlashedInUrl()
 
-        val analytics = if (urlConfig.analytics) "_a=${generateAnalyticsSignature()}" else null
+        var urlObject = URL(url)
+        val analytics = if (urlConfig.analytics && cloudConfig.authToken == null && urlObject.query == null)
+            "_a=${generateAnalyticsSignature()}"
+        else null
+
 
         return if (urlConfig.signUrl && cloudConfig.authToken != null && cloudConfig.authToken != NULL_AUTH_TOKEN) {
             val token = cloudConfig.authToken.generate(URL(url).path)

--- a/url-gen/src/test/kotlin/com/cloudinary/AuthTokenTest.kt
+++ b/url-gen/src/test/kotlin/com/cloudinary/AuthTokenTest.kt
@@ -148,7 +148,7 @@ class AuthTokenTest {
     }
 
     @Test
-    fun testAuthTokenIgnoreAnalytics() {
+    fun testAuthTokenDisableAnalytics() {
         // note: This test validates no concatenation of analytics if query param already exists.
         // This is not meant to test the string generation - This is tested separately in its own test.
 

--- a/url-gen/src/test/kotlin/com/cloudinary/AuthTokenTest.kt
+++ b/url-gen/src/test/kotlin/com/cloudinary/AuthTokenTest.kt
@@ -149,9 +149,8 @@ class AuthTokenTest {
 
     @Test
     fun testAuthTokenWithAnalytics() {
-        // note: This test validates the concatenation of analytics query param to the url.
+        // note: This test validates no concatenation of analytics if query param already exists.
         // This is not meant to test the string generation - This is tested separately in its own test.
-        val expectedAnalytics = generateAnalyticsSignature()
 
         val cloudinary =
             Cloudinary(
@@ -165,7 +164,7 @@ class AuthTokenTest {
         val url =
             cloudinary.image().generate("sample.jpg")
         assertEquals(
-            "https://res.cloudinary.com/test123/image/upload/sample.jpg?__cld_token__=st=11111111~exp=11111411~hmac=ec2d0e9a87f6dd5147c36f39c5e88c28fdaa53d1e04f3d70160f7ebe62a60c7a&_a=$expectedAnalytics",
+            "https://res.cloudinary.com/test123/image/upload/sample.jpg?__cld_token__=st=11111111~exp=11111411~hmac=ec2d0e9a87f6dd5147c36f39c5e88c28fdaa53d1e04f3d70160f7ebe62a60c7a",
             url
         )
     }

--- a/url-gen/src/test/kotlin/com/cloudinary/AuthTokenTest.kt
+++ b/url-gen/src/test/kotlin/com/cloudinary/AuthTokenTest.kt
@@ -148,7 +148,7 @@ class AuthTokenTest {
     }
 
     @Test
-    fun testAuthTokenWithAnalytics() {
+    fun testAuthTokenIgnoreAnalytics() {
         // note: This test validates no concatenation of analytics if query param already exists.
         // This is not meant to test the string generation - This is tested separately in its own test.
 


### PR DESCRIPTION
### Brief Summary of Changes
Disable addition of analytics string if query parameters or auth token already exist on the url  

#### What does this PR address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [ ] New feature
- [x] Bug fix
- [x] Adds more tests

#### Are tests included?
- [x] Yes
- [ ] No

#### Reviewer, please note:

#### Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all the tests pass.
