### PR TITLE
Add support for `g_ocr_text` in `config.js`

### DIFF
--- a/.code-generation/config.js
+++ b/.code-generation/config.js
@@ -12,7 +12,7 @@ module.exports = {
     closeQualifiersChar : ' }',
     openActionChar: '(',
     closeActionChar: ')',
-    unsupportedTxParams: ['fl_waveform', 'e_anti_removal:', 'fl_animated', 'u_', 'l_fetch', 'l_text', 'u_text', 'af_', 'if_', 'e_fade', 'c_fill', 'palette_f00', 'g_ocr_text', 'g_auto:ocr_text', '$overlaywidth_$mainvideowidth_div_3'],
+    unsupportedTxParams: ['fl_waveform', 'e_anti_removal:', 'fl_animated', 'u_', 'l_fetch', 'l_text', 'u_text', 'af_', 'if_', 'e_fade', 'c_fill', 'palette_f00', 'g_auto:ocr_text', '$overlaywidth_$mainvideowidth_div_3'],
     unsupportedSyntaxList: ['stroke(', 'textFit(', 'Animated.edit', 'RoundCorners(', 'getVideoFrame', 'Source.image', 'transcode('],
     mainTransformationString: {
       openSyntaxString: {


### PR DESCRIPTION
### Brief Summary of Changes
1. Verified that `g_ocr_text` parameter is support in code
2. There are tests for`g_ocr_text`
3. Verified that `g_ocr_text` works with the Code-Snippets service

#### What does this PR address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [x] New feature
- [ ] Bug fix
- [ ] Adds more tests

#### Are tests included?
- [x] Yes
- [ ] No

#### Reviewer, please note:

#### Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all the tests pass.
