### PR TITLE
Add support to disable b-frames for h265 video codec

### DIFF
--- a/url-gen/src/main/kotlin/com/cloudinary/transformation/transcode/TranscodeActions.kt
+++ b/url-gen/src/main/kotlin/com/cloudinary/transformation/transcode/TranscodeActions.kt
@@ -214,6 +214,8 @@ class VideoCodecLevel private constructor(private val value: String) {
         fun vcl51() = vcl51
         private val vcl52 = VideoCodecLevel("5.2")
         fun vcl52() = vcl52
+        private val auto = VideoCodecLevel("auto")
+        fun auto() = auto
     }
 
     override fun toString(): String {
@@ -314,7 +316,7 @@ class H265Codec private constructor(private val profile: VideoCodecProfile? = nu
         private fun setAutoProfileAndLevel(setAutoProfileAndLevel: Boolean) {
             if (setAutoProfileAndLevel) {
                 this.profile = VideoCodecProfile.auto()
-                this.level = "auto"
+                this.level = VideoCodecLevel.auto()
             } else {
                 this.profile = null
                 this.level = null

--- a/url-gen/src/main/kotlin/com/cloudinary/transformation/transcode/TranscodeActions.kt
+++ b/url-gen/src/main/kotlin/com/cloudinary/transformation/transcode/TranscodeActions.kt
@@ -307,17 +307,17 @@ class H265Codec private constructor(private val profile: VideoCodecProfile? = nu
         private var bFrames: Boolean = true
 
         fun bFrames(bFrames: Boolean) = apply {
-            setAutoProfileAndLevel(bFrames)
+            setAutoProfileAndLevel(!bFrames)
             this.bFrames = bFrames
         }
 
-        private fun setAutoProfileAndLevel(setAutoProfleAndLevel: Boolean) {
-            if (setAutoProfleAndLevel) {
-                this.profile = null;
-                this.level = null
-            } else {
+        private fun setAutoProfileAndLevel(setAutoProfileAndLevel: Boolean) {
+            if (setAutoProfileAndLevel) {
                 this.profile = VideoCodecProfile.auto()
                 this.level = "auto"
+            } else {
+                this.profile = null
+                this.level = null
             }
 
         }

--- a/url-gen/src/main/kotlin/com/cloudinary/transformation/transcode/TranscodeActions.kt
+++ b/url-gen/src/main/kotlin/com/cloudinary/transformation/transcode/TranscodeActions.kt
@@ -229,6 +229,8 @@ class VideoCodecProfile private constructor(private val value: String) {
         fun main() = main
         private val high = VideoCodecProfile("high")
         fun high() = high
+        private val auto = VideoCodecProfile("auto")
+        fun auto() = auto
     }
 
     override fun toString(): String {
@@ -246,6 +248,12 @@ open class VideoCodec(protected val codec: Any) {
         fun prores() = prores
         fun h264(options: (H264Codec.Builder.() -> Unit)? = null): H264Codec {
             val builder = H264Codec.Builder()
+            options?.let { builder.it() }
+            return builder.build()
+        }
+
+        fun h265(options: (H265Codec.Builder.() -> Unit)? = null): H265Codec {
+            val builder = H265Codec.Builder()
             options?.let { builder.it() }
             return builder.build()
         }
@@ -280,6 +288,41 @@ class H264Codec private constructor(private val profile: VideoCodecProfile? = nu
         fun level(level: Expression) = apply { this.level = level }
 
         fun build() = H264Codec(profile, level)
+    }
+}
+
+class H265Codec private constructor(private val profile: VideoCodecProfile? = null, private val level: Any? = null, private val bFrames: Boolean = true) :
+    VideoCodec("h265") {
+    override fun toString(): String {
+        var bFramesString: String? = null
+        if (!bFrames) {
+            bFramesString = "bframes_no"
+        }
+        return codec.joinWithValues(profile, level, bFramesString)
+    }
+
+    class Builder {
+        private var profile: VideoCodecProfile? = null
+        private var level: Any? = null
+        private var bFrames: Boolean = true
+
+        fun bFrames(bFrames: Boolean) = apply {
+            setAutoProfileAndLevel(bFrames)
+            this.bFrames = bFrames
+        }
+
+        private fun setAutoProfileAndLevel(setAutoProfleAndLevel: Boolean) {
+            if (setAutoProfleAndLevel) {
+                this.profile = null;
+                this.level = null
+            } else {
+                this.profile = VideoCodecProfile.auto()
+                this.level = "auto"
+            }
+
+        }
+
+        fun build() = H265Codec(profile, level, bFrames)
     }
 }
 

--- a/url-gen/src/test/kotlin/com/cloudinary/transformation/TranscodeTest.kt
+++ b/url-gen/src/test/kotlin/com/cloudinary/transformation/TranscodeTest.kt
@@ -48,6 +48,14 @@ class TranscodeTest {
             profile(VideoCodecProfile.high())
             level(VideoCodecLevel.vcl31())
         }))
+
+        cldAssert("vc_h265", videoCodec(VideoCodec.h265()))
+    }
+
+    @Test
+    fun testDisableBFrames() {
+        cldAssert("vc_h265:auto:auto:bframes_no", videoCodec(VideoCodec.h265 { bFrames(false) }))
+        cldAssert("vc_h265", videoCodec(VideoCodec.h265 { bFrames(true) }))
     }
 
     @Test


### PR DESCRIPTION
### Brief Summary of Changes
Add support to disable b-frames on H265 video codec

#### What does this PR address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [x] New feature
- [ ] Bug fix
- [x] Adds more tests

#### Are tests included?
- [x] Yes
- [ ] No

#### Reviewer, please note:

#### Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all the tests pass.
