### PR TITLE
Support `transcode` in `config.js`

### DIFF
--- a/.code-generation/config.js
+++ b/.code-generation/config.js
@@ -13,7 +13,7 @@ module.exports = {
     openActionChar: '(',
     closeActionChar: ')',
     unsupportedTxParams: ['fl_waveform', 'e_anti_removal:', 'fl_animated', 'l_fetch', 'l_text', 'u_text', 'af_', 'if_', 'e_fade', 'palette_f00', 'g_auto:ocr_text', '$overlaywidth_$mainvideowidth_div_3'],
-    unsupportedSyntaxList: ['stroke(', 'textFit(', 'Animated.edit', 'RoundCorners(', 'getVideoFrame', 'transcode('],
+    unsupportedSyntaxList: ['stroke(', 'textFit(', 'Animated.edit', 'RoundCorners(', 'getVideoFrame'],
     mainTransformationString: {
       openSyntaxString: {
         image: 'cloudinary.image {\n\tpublicId("#publicID")',

--- a/url-gen/src/main/kotlin/com/cloudinary/transformation/transcode/TranscodeActions.kt
+++ b/url-gen/src/main/kotlin/com/cloudinary/transformation/transcode/TranscodeActions.kt
@@ -37,6 +37,7 @@ class ToAnimated(
 
         fun sampling(videoSampling: Int) = apply { this.sampling = videoSampling }
         fun sampling(videoSampling: String) = apply { this.sampling = videoSampling }
+        @Deprecated("This function will be removed in the next major version")
         fun delay(delay: Int) = apply { this.delay = delay }
 
         override fun build() = ToAnimated(animatedFormat, sampling, delay)


### PR DESCRIPTION
### Brief Summary of Changes
1. Verified that `transcode` parameter is support in code
2. There are tests for `transcode`
3. Deprecate `delay` from `Transcode.toAnimated`


#### What does this PR address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [x] New feature
- [ ] Bug fix
- [ ] Adds more tests

#### Are tests included?
- [x] Yes
- [ ] No

#### Reviewer, please note:

#### Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all the tests pass.
