### PR TITLE
Fix URL encode typo

### DIFF
--- a/url-gen/src/main/kotlin/com/cloudinary/util/StringUtils.kt
+++ b/url-gen/src/main/kotlin/com/cloudinary/util/StringUtils.kt
@@ -102,7 +102,7 @@ internal fun String.cldMergeToSingleUnderscore(): String {
 internal fun String.cldSmartUrlEncode() = URLEncoder.encode(this, "UTF-8")
     .replace("%2F", "/")
     .replace("%3A", ":")
-    .replace("+", "%20")
+    .replace("+", "%2B")
 
 
 /**


### PR DESCRIPTION
### Brief Summary of Changes
Fix URL encode type where "+" was replaced by "%20" instead of "%2B"

#### What does this PR address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [ ] New feature
- [x] Bug fix
- [ ] Adds more tests

#### Are tests included?
- [x] Yes
- [ ] No

#### Reviewer, please note:


#### Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all the tests pass.
