### PR TITLE
Fix analytics class warnings

### DIFF
--- a/url-gen/src/main/kotlin/com/cloudinary/Analytics.kt
+++ b/url-gen/src/main/kotlin/com/cloudinary/Analytics.kt
@@ -62,7 +62,6 @@ private fun generateOSVersionString(major: Any, minor: Any? = "0", patch: Any? =
 }
 
 private fun String.toAnalyticsVersionStr(): String {
-    val num = this.toInt(2)
     return when (val num = this.toInt(2)) {
         in 0..25 -> {
             ('A' + num).toString()

--- a/url-gen/src/main/kotlin/com/cloudinary/Analytics.kt
+++ b/url-gen/src/main/kotlin/com/cloudinary/Analytics.kt
@@ -54,11 +54,11 @@ private fun generateVersionString(major: Any, minor: Any, patch: Any? = null): S
 }
 
 private fun generateOSVersionString(major: Any, minor: Any? = "0", patch: Any? = null): String {
-    val patchStr = if (patch != null) patch.toString().toAnalyticsVersionStr() else ""
+    val patchStr = patch?.toString()?.toAnalyticsVersionStr() ?: ""
     val minorStr = minor.toString().padStart(2, '0').toLong().toString(2).toAnalyticsVersionStr()
     val majorStr = major.toString().padStart(2, '0').toLong().toString(2).toAnalyticsVersionStr()
 
-    return "$majorStr$minorStr"
+    return "$majorStr$minorStr$patchStr"
 }
 
 private fun String.toAnalyticsVersionStr(): String {


### PR DESCRIPTION
### Brief Summary of Changes
This pull request includes a small but important change to the `generateOSVersionString` method in the `Analytics.kt` file. The change ensures that the patch version is correctly included in the generated version string.
Also, the local num variable inside the `toAnalyticsVersionStr` has been removed.

#### What does this PR address?
- [X] GitHub issue - #108 
- [X] Refactoring
- [ ] New feature
- [ ] Bug fix
- [ ] Adds more tests

#### Are tests included?
- [ ] Yes
- [X] No

#### Reviewer, please note:
N/A

#### Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I ran the full test suite before pushing the changes and all the tests pass.
